### PR TITLE
Remove "Azure" prefix from class names

### DIFF
--- a/src/AzureServiceBus.Tests/APIApprovals.cs
+++ b/src/AzureServiceBus.Tests/APIApprovals.cs
@@ -11,7 +11,7 @@
         [Test]
         public void Approve()
         {
-            var publicApi = ApiGenerator.GeneratePublicApi(typeof(AzureServiceBusTriggeredEndpointConfiguration).Assembly, excludeAttributes: new[] { "System.Runtime.Versioning.TargetFrameworkAttribute" });
+            var publicApi = ApiGenerator.GeneratePublicApi(typeof(ServiceBusTriggeredEndpointConfiguration).Assembly, excludeAttributes: new[] { "System.Runtime.Versioning.TargetFrameworkAttribute" });
             Approver.Verify(publicApi);
         }
     }

--- a/src/AzureServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/AzureServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -1,15 +1,15 @@
 namespace NServiceBus.AzureFunctions.AzureServiceBus
 {
-    public class AzureFunctionEndpoint : NServiceBus.Serverless.ServerlessEndpoint<Microsoft.Azure.WebJobs.ExecutionContext>
+    public class FunctionEndpoint : NServiceBus.Serverless.ServerlessEndpoint<Microsoft.Azure.WebJobs.ExecutionContext>
     {
-        public AzureFunctionEndpoint(System.Func<Microsoft.Azure.WebJobs.ExecutionContext, NServiceBus.Serverless.ServerlessEndpointConfiguration> configurationFactory) { }
+        public FunctionEndpoint(System.Func<Microsoft.Azure.WebJobs.ExecutionContext, NServiceBus.Serverless.ServerlessEndpointConfiguration> configurationFactory) { }
     }
-    public class AzureServiceBusTriggeredEndpointConfiguration : NServiceBus.Serverless.ServerlessEndpointConfiguration
+    public class ServiceBusTriggeredEndpointConfiguration : NServiceBus.Serverless.ServerlessEndpointConfiguration
     {
-        public AzureServiceBusTriggeredEndpointConfiguration(string endpointName) { }
+        public ServiceBusTriggeredEndpointConfiguration(string endpointName) { }
     }
-    public class static AzureServiceBusTriggerExtensions
+    public class static ServiceBusTriggerExtensions
     {
-        public static System.Threading.Tasks.Task Process(this NServiceBus.AzureFunctions.AzureServiceBus.AzureFunctionEndpoint endpoint, Microsoft.Azure.ServiceBus.Message message, Microsoft.Azure.WebJobs.ExecutionContext executionContext) { }
+        public static System.Threading.Tasks.Task Process(this NServiceBus.AzureFunctions.AzureServiceBus.FunctionEndpoint endpoint, Microsoft.Azure.ServiceBus.Message message, Microsoft.Azure.WebJobs.ExecutionContext executionContext) { }
     }
 }

--- a/src/AzureStorageQueues.Tests/APIApprovals.cs
+++ b/src/AzureStorageQueues.Tests/APIApprovals.cs
@@ -11,7 +11,7 @@
         [Test]
         public void Approve()
         {
-            var publicApi = ApiGenerator.GeneratePublicApi(typeof(AzureStorageQueueTriggeredEndpointConfiguration).Assembly, excludeAttributes: new[] { "System.Runtime.Versioning.TargetFrameworkAttribute" });
+            var publicApi = ApiGenerator.GeneratePublicApi(typeof(StorageQueueTriggeredEndpointConfiguration).Assembly, excludeAttributes: new[] { "System.Runtime.Versioning.TargetFrameworkAttribute" });
             Approver.Verify(publicApi);
         }
     }

--- a/src/AzureStorageQueues.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/AzureStorageQueues.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -1,15 +1,15 @@
 namespace NServiceBus.AzureFunctions.AzureStorageQueues
 {
-    public class AzureFunctionEndpoint : NServiceBus.Serverless.ServerlessEndpoint<Microsoft.Azure.WebJobs.ExecutionContext>
+    public class FunctionEndpoint : NServiceBus.Serverless.ServerlessEndpoint<Microsoft.Azure.WebJobs.ExecutionContext>
     {
-        public AzureFunctionEndpoint(System.Func<Microsoft.Azure.WebJobs.ExecutionContext, NServiceBus.Serverless.ServerlessEndpointConfiguration> configurationFactory) { }
+        public FunctionEndpoint(System.Func<Microsoft.Azure.WebJobs.ExecutionContext, NServiceBus.Serverless.ServerlessEndpointConfiguration> configurationFactory) { }
     }
-    public class AzureStorageQueueTriggeredEndpointConfiguration : NServiceBus.Serverless.ServerlessEndpointConfiguration
+    public class StorageQueueTriggeredEndpointConfiguration : NServiceBus.Serverless.ServerlessEndpointConfiguration
     {
-        public AzureStorageQueueTriggeredEndpointConfiguration(string endpointName) { }
+        public StorageQueueTriggeredEndpointConfiguration(string endpointName) { }
     }
-    public class static AzureStorageQueueTriggerExtensions
+    public class static StorageQueueTriggerExtensions
     {
-        public static System.Threading.Tasks.Task Process(this NServiceBus.AzureFunctions.AzureStorageQueues.AzureFunctionEndpoint endpoint, Microsoft.WindowsAzure.Storage.Queue.CloudQueueMessage message, Microsoft.Azure.WebJobs.ExecutionContext executionContext) { }
+        public static System.Threading.Tasks.Task Process(this NServiceBus.AzureFunctions.AzureStorageQueues.FunctionEndpoint endpoint, Microsoft.WindowsAzure.Storage.Queue.CloudQueueMessage message, Microsoft.Azure.WebJobs.ExecutionContext executionContext) { }
     }
 }

--- a/src/NServiceBus.AzureFunctions.AzureServiceBus/FunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.AzureServiceBus/FunctionEndpoint.cs
@@ -1,19 +1,19 @@
 ﻿namespace NServiceBus.AzureFunctions.AzureServiceBus
 {
-    using System;
     using Microsoft.Azure.WebJobs;
     using Serverless;
+    using System;
 
     /// <summary>
     /// An NServiceBus endpoint hosted in Azure Function which does not receive messages automatically but only handles
     /// messages explicitly passed to it by the caller.
     /// </summary>
-    public class AzureFunctionEndpoint : ServerlessEndpoint<ExecutionContext>
+    public class FunctionEndpoint : ServerlessEndpoint<ExecutionContext>
     {
         /// <summary>
         /// Create a new endpoint hosting in Azure Function.
         /// </summary>
-        public AzureFunctionEndpoint(Func<ExecutionContext, ServerlessEndpointConfiguration> configurationFactory) : base(configurationFactory)
+        public FunctionEndpoint(Func<ExecutionContext, ServerlessEndpointConfiguration> configurationFactory) : base(configurationFactory)
         {
         }}
 }

--- a/src/NServiceBus.AzureFunctions.AzureServiceBus/ServiceBusTriggerExtensions.cs
+++ b/src/NServiceBus.AzureFunctions.AzureServiceBus/ServiceBusTriggerExtensions.cs
@@ -1,23 +1,23 @@
 ﻿namespace NServiceBus.AzureFunctions.AzureServiceBus
 {
+    using Extensibility;
+    using Microsoft.Azure.ServiceBus;
     using System;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
-    using Extensibility;
-    using Microsoft.Azure.ServiceBus;
     using Transport;
     using ExecutionContext = Microsoft.Azure.WebJobs.ExecutionContext;
 
     /// <summary>
     /// Extension methods for a ServerlessEndpoint when using AzureServiceBus triggers.
     /// </summary>
-    public static class AzureServiceBusTriggerExtensions
+    public static class ServiceBusTriggerExtensions
     {
         /// <summary>
         /// Processes a message received from an AzureServiceBus trigger using the NServiceBus message pipeline.
         /// </summary>
-        public static Task Process(this AzureFunctionEndpoint endpoint, Message message, ExecutionContext executionContext)
+        public static Task Process(this FunctionEndpoint endpoint, Message message, ExecutionContext executionContext)
         {
             var context = new MessageContext(
                 Guid.NewGuid().ToString("N"),

--- a/src/NServiceBus.AzureFunctions.AzureServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.AzureServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
@@ -5,13 +5,13 @@
     /// <summary>
     /// Represents a serverless NServiceBus endpoint running within an AzureServiceBus trigger.
     /// </summary>
-    public class AzureServiceBusTriggeredEndpointConfiguration : ServerlessEndpointConfiguration
+    public class ServiceBusTriggeredEndpointConfiguration : ServerlessEndpointConfiguration
     {
         /// <summary>
         /// Creates a serverless NServiceBus endpoint running within an AzureServiceBus trigger.
         /// </summary>
         /// <param name="endpointName"></param>
-        public AzureServiceBusTriggeredEndpointConfiguration(string endpointName) : base(endpointName)
+        public ServiceBusTriggeredEndpointConfiguration(string endpointName) : base(endpointName)
         {
             //handle retries by native queue capabilities
             InMemoryRetries(0);

--- a/src/NServiceBus.AzureFunctions.AzureStorageQueues/FunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.AzureStorageQueues/FunctionEndpoint.cs
@@ -1,19 +1,19 @@
 ﻿namespace NServiceBus.AzureFunctions.AzureStorageQueues
 {
-    using System;
     using Microsoft.Azure.WebJobs;
     using Serverless;
+    using System;
 
     /// <summary>
     /// An NServiceBus endpoint hosted in Azure Function which does not receive messages automatically but only handles
     /// messages explicitly passed to it by the caller.
     /// </summary>
-    public class AzureFunctionEndpoint : ServerlessEndpoint<ExecutionContext>
+    public class FunctionEndpoint : ServerlessEndpoint<ExecutionContext>
     {
         /// <summary>
         /// Create a new endpoint hosting in Azure Function.
         /// </summary>
-        public AzureFunctionEndpoint(Func<ExecutionContext, ServerlessEndpointConfiguration> configurationFactory) : base(configurationFactory)
+        public FunctionEndpoint(Func<ExecutionContext, ServerlessEndpointConfiguration> configurationFactory) : base(configurationFactory)
         {
         }}
 }

--- a/src/NServiceBus.AzureFunctions.AzureStorageQueues/StorageQueueTriggerExtensions.cs
+++ b/src/NServiceBus.AzureFunctions.AzureStorageQueues/StorageQueueTriggerExtensions.cs
@@ -1,25 +1,25 @@
 ﻿namespace NServiceBus.AzureFunctions.AzureStorageQueues
 {
-    using System;
-    using System.IO;
-    using System.Threading;
-    using System.Threading.Tasks;
     using Azure.Transports.WindowsAzureStorageQueues;
     using Extensibility;
     using Microsoft.WindowsAzure.Storage.Queue;
     using Newtonsoft.Json;
+    using System;
+    using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Transport;
     using ExecutionContext = Microsoft.Azure.WebJobs.ExecutionContext;
 
     /// <summary>
     /// Extension methods for a ServerlessEndpoint when using AzureStorageQueue triggers.
     /// </summary>
-    public static class AzureStorageQueueTriggerExtensions
+    public static class StorageQueueTriggerExtensions
     {
         /// <summary>
         /// Processes a message received from an AzureStorageQueue trigger using the NServiceBus message pipeline.
         /// </summary>
-        public static Task Process(this AzureFunctionEndpoint endpoint, CloudQueueMessage message, ExecutionContext executionContext)
+        public static Task Process(this FunctionEndpoint endpoint, CloudQueueMessage message, ExecutionContext executionContext)
         {
             var serializer = new JsonSerializer();
             var msg = serializer.Deserialize<MessageWrapper>(

--- a/src/NServiceBus.AzureFunctions.AzureStorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.AzureStorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
@@ -5,13 +5,13 @@
     /// <summary>
     /// Represents a serverless NServiceBus endpoint running within an AzureStorageQueue trigger.
     /// </summary>
-    public class AzureStorageQueueTriggeredEndpointConfiguration : ServerlessEndpointConfiguration
+    public class StorageQueueTriggeredEndpointConfiguration : ServerlessEndpointConfiguration
     {
         /// <summary>
         /// Creates a serverless NServiceBus endpoint running within an AzureStorageQueue trigger.
         /// </summary>
         /// <param name="endpointName"></param>
-        public AzureStorageQueueTriggeredEndpointConfiguration(string endpointName) : base(endpointName)
+        public StorageQueueTriggeredEndpointConfiguration(string endpointName) : base(endpointName)
         {
             //handle retries by native queue capabilities
             InMemoryRetries(0);


### PR DESCRIPTION
_Changes started by https://github.com/ParticularLabs/NServiceBus.AzureFunctions/pull/3#discussion_r317050057_

Removes the "Azure" prefix from the class names only. Projects are not renamed in this PR to avoid TC/Octopus work that should take place later to address it in a separate issue (https://github.com/ParticularLabs/NServiceBus.AzureFunctions/issues/5).