### PR TITLE
Clone headers for ErrorContext

### DIFF
--- a/src/NServiceBus.AzureFunctions.ServiceBus/FunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/FunctionEndpoint.cs
@@ -38,7 +38,7 @@
             {
                 var errorContext = new ErrorContext(
                     exception,
-                    new Dictionary<string, string>(messageContext.Headers),
+                    message.GetHeaders(),
                     messageContext.MessageId,
                     messageContext.Body,
                     new TransportTransaction(), 

--- a/src/NServiceBus.AzureFunctions.StorageQueues/FunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/FunctionEndpoint.cs
@@ -43,7 +43,7 @@
             {
                 var errorContext = new ErrorContext(
                     exception,
-                    new Dictionary<string, string>(messageContext.Headers),
+                    wrapper.GetHeaders(),
                     messageContext.MessageId,
                     messageContext.Body,
                     new TransportTransaction(), 


### PR DESCRIPTION
we need a fresh set of headers instead of cloning the ones from the message context as those could have been modified already at this point.