### PR TITLE
Derive endpoint name from function name

### DIFF
--- a/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
@@ -18,10 +18,9 @@
         /// <summary>
         /// Creates a serverless NServiceBus endpoint running within an Azure Service Bus trigger.
         /// </summary>
-        /// <param name="endpointName"></param>
         /// <param name="connectionStringName"></param>
         /// <param name="executionContext"></param>
-        public ServiceBusTriggeredEndpointConfiguration(string endpointName, string connectionStringName, ExecutionContext executionContext) : base(endpointName)
+        public ServiceBusTriggeredEndpointConfiguration(string connectionStringName, ExecutionContext executionContext) : base(executionContext.FunctionName)
         {
             Transport = UseTransport<AzureServiceBusTransport>();
 

--- a/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
@@ -17,10 +17,9 @@
         /// <summary>
         /// Creates a serverless NServiceBus endpoint running within an AzureStorageQueue trigger.
         /// </summary>
-        /// <param name="endpointName"></param>
         /// <param name="connectionStringName"></param>
         /// <param name="executionContext"></param>
-        public StorageQueueTriggeredEndpointConfiguration(string endpointName, string connectionStringName, ExecutionContext executionContext) : base(endpointName)
+        public StorageQueueTriggeredEndpointConfiguration(string connectionStringName, ExecutionContext executionContext) : base(executionContext.FunctionName)
         {
             Transport = UseTransport<AzureStorageQueueTransport>();
 

--- a/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -7,7 +7,7 @@ namespace NServiceBus.AzureFunctions.ServiceBus
     }
     public class ServiceBusTriggeredEndpointConfiguration : NServiceBus.Serverless.ServerlessEndpointConfiguration
     {
-        public ServiceBusTriggeredEndpointConfiguration(string endpointName, string connectionStringName, Microsoft.Azure.WebJobs.ExecutionContext executionContext) { }
+        public ServiceBusTriggeredEndpointConfiguration(string connectionStringName, Microsoft.Azure.WebJobs.ExecutionContext executionContext) { }
         public NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> Transport { get; }
     }
 }

--- a/src/StorageQueues.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/StorageQueues.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -7,7 +7,7 @@ namespace NServiceBus.AzureFunctions.StorageQueues
     }
     public class StorageQueueTriggeredEndpointConfiguration : NServiceBus.Serverless.ServerlessEndpointConfiguration
     {
-        public StorageQueueTriggeredEndpointConfiguration(string endpointName, string connectionStringName, Microsoft.Azure.WebJobs.ExecutionContext executionContext) { }
+        public StorageQueueTriggeredEndpointConfiguration(string connectionStringName, Microsoft.Azure.WebJobs.ExecutionContext executionContext) { }
         public NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> Transport { get; }
     }
 }


### PR DESCRIPTION
makes the API easier to use because users won't have to define a endpoint name constant or something like that but instead we can automatically derive the endpoint name from the function name.

This would also simplify the sample a litte bit further.