### PR TITLE
Support environment variables

### DIFF
--- a/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.AzureFunctions.ServiceBus
 {
     using Microsoft.Azure.WebJobs;
-    using Microsoft.Extensions.Configuration;
     using Serverless;
 
     /// <summary>
@@ -9,7 +8,6 @@
     /// </summary>
     public class ServiceBusTriggeredEndpointConfiguration : ServerlessEndpointConfiguration
     {
-
         /// <summary>
         /// Azure Service Bus transport
         /// </summary>
@@ -24,11 +22,8 @@
         {
             Transport = UseTransport<AzureServiceBusTransport>();
 
-            var config = new ConfigurationBuilder()
-                .SetBasePath(executionContext.FunctionAppDirectory)
-                .AddJsonFile("local.settings.json", optional: true)
-                .Build();
-            Transport.ConnectionString(config.GetValue<string>($"Values:{connectionStringName}"));
+            var connectionString = System.Environment.GetEnvironmentVariable(connectionStringName);
+            Transport.ConnectionString(connectionString);
         }
     }
 }

--- a/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
@@ -16,9 +16,7 @@
         /// <summary>
         /// Creates a serverless NServiceBus endpoint running within an Azure Service Bus trigger.
         /// </summary>
-        /// <param name="connectionStringName"></param>
-        /// <param name="executionContext"></param>
-        public ServiceBusTriggeredEndpointConfiguration(string connectionStringName, ExecutionContext executionContext) : base(executionContext.FunctionName)
+        public ServiceBusTriggeredEndpointConfiguration(ExecutionContext executionContext, string connectionStringName = "AzureWebJobsServiceBus") : base(executionContext.FunctionName)
         {
             Transport = UseTransport<AzureServiceBusTransport>();
 

--- a/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
@@ -18,10 +18,9 @@
         /// <summary>
         /// Creates a serverless NServiceBus endpoint running within an Azure Service Bus trigger.
         /// </summary>
-        /// <param name="endpointName"></param>
         /// <param name="connectionStringName"></param>
         /// <param name="executionContext"></param>
-        public ServiceBusTriggeredEndpointConfiguration(string endpointName, string connectionStringName, ExecutionContext executionContext) : base(endpointName)
+        public ServiceBusTriggeredEndpointConfiguration(string connectionStringName, ExecutionContext executionContext) : base(executionContext.FunctionName)
         {
             Transport = UseTransport<AzureServiceBusTransport>();
 

--- a/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.AzureFunctions.StorageQueues
 {
     using Microsoft.Azure.WebJobs;
-    using Microsoft.Extensions.Configuration;
     using Serverless;
 
     /// <summary>
@@ -23,11 +22,8 @@
         {
             Transport = UseTransport<AzureStorageQueueTransport>();
 
-            var config = new ConfigurationBuilder()
-                .SetBasePath(executionContext.FunctionAppDirectory)
-                .AddJsonFile("local.settings.json", optional: true)
-                .Build();
-            Transport.ConnectionString(config.GetValue<string>($"Values:{connectionStringName}"));
+            var connectionString = System.Environment.GetEnvironmentVariable(connectionStringName);
+            Transport.ConnectionString(connectionString);
         }
     }
 }

--- a/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
@@ -17,10 +17,9 @@
         /// <summary>
         /// Creates a serverless NServiceBus endpoint running within an AzureStorageQueue trigger.
         /// </summary>
-        /// <param name="endpointName"></param>
         /// <param name="connectionStringName"></param>
         /// <param name="executionContext"></param>
-        public StorageQueueTriggeredEndpointConfiguration(string endpointName, string connectionStringName, ExecutionContext executionContext) : base(endpointName)
+        public StorageQueueTriggeredEndpointConfiguration(string connectionStringName, ExecutionContext executionContext) : base(executionContext.FunctionName)
         {
             Transport = UseTransport<AzureStorageQueueTransport>();
 

--- a/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
@@ -16,9 +16,7 @@
         /// <summary>
         /// Creates a serverless NServiceBus endpoint running within an AzureStorageQueue trigger.
         /// </summary>
-        /// <param name="connectionStringName"></param>
-        /// <param name="executionContext"></param>
-        public StorageQueueTriggeredEndpointConfiguration(string connectionStringName, ExecutionContext executionContext) : base(executionContext.FunctionName)
+        public StorageQueueTriggeredEndpointConfiguration(ExecutionContext executionContext, string connectionStringName = "AzureWebJobsStorage") : base(executionContext.FunctionName)
         {
             Transport = UseTransport<AzureStorageQueueTransport>();
 

--- a/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -7,7 +7,7 @@ namespace NServiceBus.AzureFunctions.ServiceBus
     }
     public class ServiceBusTriggeredEndpointConfiguration : NServiceBus.Serverless.ServerlessEndpointConfiguration
     {
-        public ServiceBusTriggeredEndpointConfiguration(string connectionStringName, Microsoft.Azure.WebJobs.ExecutionContext executionContext) { }
+        public ServiceBusTriggeredEndpointConfiguration(Microsoft.Azure.WebJobs.ExecutionContext executionContext, string connectionStringName = "AzureWebJobsServiceBus") { }
         public NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> Transport { get; }
     }
 }

--- a/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -7,7 +7,7 @@ namespace NServiceBus.AzureFunctions.ServiceBus
     }
     public class ServiceBusTriggeredEndpointConfiguration : NServiceBus.Serverless.ServerlessEndpointConfiguration
     {
-        public ServiceBusTriggeredEndpointConfiguration(string endpointName, string connectionStringName, Microsoft.Azure.WebJobs.ExecutionContext executionContext) { }
+        public ServiceBusTriggeredEndpointConfiguration(string connectionStringName, Microsoft.Azure.WebJobs.ExecutionContext executionContext) { }
         public NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> Transport { get; }
     }
 }

--- a/src/StorageQueues.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/StorageQueues.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -7,7 +7,7 @@ namespace NServiceBus.AzureFunctions.StorageQueues
     }
     public class StorageQueueTriggeredEndpointConfiguration : NServiceBus.Serverless.ServerlessEndpointConfiguration
     {
-        public StorageQueueTriggeredEndpointConfiguration(string endpointName, string connectionStringName, Microsoft.Azure.WebJobs.ExecutionContext executionContext) { }
+        public StorageQueueTriggeredEndpointConfiguration(string connectionStringName, Microsoft.Azure.WebJobs.ExecutionContext executionContext) { }
         public NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> Transport { get; }
     }
 }

--- a/src/StorageQueues.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/StorageQueues.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -7,7 +7,7 @@ namespace NServiceBus.AzureFunctions.StorageQueues
     }
     public class StorageQueueTriggeredEndpointConfiguration : NServiceBus.Serverless.ServerlessEndpointConfiguration
     {
-        public StorageQueueTriggeredEndpointConfiguration(string connectionStringName, Microsoft.Azure.WebJobs.ExecutionContext executionContext) { }
+        public StorageQueueTriggeredEndpointConfiguration(Microsoft.Azure.WebJobs.ExecutionContext executionContext, string connectionStringName = "AzureWebJobsStorage") { }
         public NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> Transport { get; }
     }
 }


### PR DESCRIPTION
Note: this PR is built in top of #15 which needs to merged before.

The current configuration requires the connection string to be stored in a local.settings.json. Therefore users can't use connection strings configured in the portal as environment variables. As the local.settings.json "values" will be available as environment variables automatically, we can just fetch the name from the environment variables which makes this more flexible and useful.

I've also made the connectionstring name an optional parameter configured to the default trigger specific connection strings documented [here for ASB](https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus#trigger---configuration) and [here for ASQ](https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue#trigger---configuration).