### PR TITLE
Set recoverability settings back to the NServiceBus defaults

### DIFF
--- a/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
@@ -22,8 +22,9 @@
             var connectionString = System.Environment.GetEnvironmentVariable(connectionStringName);
             Transport.ConnectionString(connectionString);
 
-            this.AdvancedConfiguration.Recoverability().Immediate(settings => settings.NumberOfRetries(5));
-            this.AdvancedConfiguration.Recoverability().Delayed(settings => settings.NumberOfRetries(3));
+            var recoverability = AdvancedConfiguration.Recoverability();
+            recoverability.Immediate(settings => settings.NumberOfRetries(5));
+            recoverability.Delayed(settings => settings.NumberOfRetries(3));
         }
     }
 }

--- a/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
@@ -21,6 +21,9 @@
 
             var connectionString = System.Environment.GetEnvironmentVariable(connectionStringName);
             Transport.ConnectionString(connectionString);
+
+            this.AdvancedConfiguration.Recoverability().Immediate(settings => settings.NumberOfRetries(5));
+            this.AdvancedConfiguration.Recoverability().Delayed(settings => settings.NumberOfRetries(3));
         }
     }
 }

--- a/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
@@ -22,8 +22,9 @@
             var connectionString = System.Environment.GetEnvironmentVariable(connectionStringName);
             Transport.ConnectionString(connectionString);
 
-            this.AdvancedConfiguration.Recoverability().Immediate(settings => settings.NumberOfRetries(4));
-            this.AdvancedConfiguration.Recoverability().Delayed(settings => settings.NumberOfRetries(3));
+            var recoverability = AdvancedConfiguration.Recoverability();
+            recoverability.Immediate(settings => settings.NumberOfRetries(4));
+            recoverability.Delayed(settings => settings.NumberOfRetries(3));
         }
     }
 }

--- a/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
@@ -21,6 +21,9 @@
 
             var connectionString = System.Environment.GetEnvironmentVariable(connectionStringName);
             Transport.ConnectionString(connectionString);
+
+            this.AdvancedConfiguration.Recoverability().Immediate(settings => settings.NumberOfRetries(4));
+            this.AdvancedConfiguration.Recoverability().Delayed(settings => settings.NumberOfRetries(3));
         }
     }
 }


### PR DESCRIPTION
Azure Functions can do immediate and delayed retries. While there's some issue with the ASQ delayed retries, ASB worked flawlessly.
Suggested changes:
- Set ASB recoverability to the defaults (5 immediate retries and 3 delayed).
- Set ASQ recoverability to what the Functions SDK can handle (4 immediate retries and 3 delayed).
  - The ASQ trigger can only handle 5 deliveries before it dead-letters the message. With the default 5 immediate retries and one normal processing that is one attempt too much.

I didn't know if there's a way to reset recoverability attempt to the defaults.
I've also contemplated removing the code that disables recoverability in NServiceBus.Serverless, but wasn't sure if that will affect AWS Lambda negatively or not. @boblangley or @danielmarbach could you please confirm if removing the code in https://github.com/ParticularLabs/NServiceBus.Serverless/blob/9664da1627f2187ef8d46feb58d4f50bd648f3ff/src/NServiceBus.Serverless/ServerlessEndpointConfiguration.cs#L23 will affect Lambda or not? Thank you.