### PR TITLE
Auto configuration via reflection

### DIFF
--- a/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
@@ -1,7 +1,9 @@
 ﻿namespace NServiceBus.AzureFunctions.ServiceBus
 {
-    using Microsoft.Extensions.Logging;
-    using Logging;
+    using System;
+    using System.Diagnostics;
+    using System.Reflection;
+    using Microsoft.Azure.WebJobs;
     using Serverless;
 
     /// <summary>
@@ -9,6 +11,8 @@
     /// </summary>
     public class ServiceBusTriggeredEndpointConfiguration : ServerlessEndpointConfiguration
     {
+        const string DefaultServiceBusConnectionName = "AzureWebJobsServiceBus";
+
         /// <summary>
         /// Azure Service Bus transport
         /// </summary>
@@ -23,7 +27,7 @@
         {
             Transport = UseTransport<AzureServiceBusTransport>();
 
-            var connectionString = System.Environment.GetEnvironmentVariable(connectionStringName);
+            var connectionString = Environment.GetEnvironmentVariable(connectionStringName ?? DefaultServiceBusConnectionName);
             Transport.ConnectionString(connectionString);
 
             var recoverability = AdvancedConfiguration.Recoverability();
@@ -32,6 +36,45 @@
 
             FunctionsLoggerFactory = new FunctionsLoggerFactory(logger);
             LogManager.UseFactory(FunctionsLoggerFactory);
+        }
+
+        /// <summary>
+        /// Attempts to derive the required configuration parameters automatically from the Azure functions related attributes via reflection.
+        /// </summary>
+        public static ServiceBusTriggeredEndpointConfiguration AutoConfigure()
+        {
+            var configuration = TryGetTriggerConfiguration();
+            if (configuration != null)
+            {
+                return new ServiceBusTriggeredEndpointConfiguration(configuration.QueueName, configuration.Connection);
+            }
+
+            throw new Exception($"Unable to automatically derive the endpoint name from the ServiceBusTrigger attribute. Make sure the attribute exists or create the {nameof(ServiceBusTriggeredEndpointConfiguration)} with the required parameter manually.");
+
+            ServiceBusTriggerAttribute TryGetTriggerConfiguration()
+            {
+                var frames = new StackTrace().GetFrames();
+                foreach (var stackFrame in frames)
+                {
+                    var method = stackFrame.GetMethod();
+                    var functionAttribute = method.GetCustomAttribute<FunctionNameAttribute>(false);
+                    if (functionAttribute != null)
+                    {
+                        foreach (var parameter in method.GetParameters())
+                        {
+                            var triggerConfiguration = parameter.GetCustomAttribute<ServiceBusTriggerAttribute>(false);
+                            if (triggerConfiguration != null)
+                            {
+                                return triggerConfiguration;
+                            }
+                        }
+                    }
+
+                    return null;
+                }
+
+                return null;
+            }
         }
     }
 }

--- a/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
@@ -44,12 +44,12 @@
         /// <summary>
         /// Attempts to derive the required configuration parameters automatically from the Azure Functions related attributes via reflection.
         /// </summary>
-        public static ServiceBusTriggeredEndpointConfiguration CreateUsingFunctionAndTriggerAttributesInformation()
+        public static ServiceBusTriggeredEndpointConfiguration CreateUsingFunctionAndTriggerAttributesInformation(FunctionExecutionContext functionExecutionContext)
         {
             var configuration = TryGetTriggerConfiguration();
             if (configuration != null)
             {
-                return new ServiceBusTriggeredEndpointConfiguration(configuration.QueueName, NullLogger.Instance, configuration.Connection);
+                return new ServiceBusTriggeredEndpointConfiguration(configuration.QueueName, functionExecutionContext.Logger ?? NullLogger.Instance, configuration.Connection);
             }
 
             throw new Exception($"Unable to automatically derive the endpoint name from the ServiceBusTrigger attribute. Make sure the attribute exists or create the {nameof(ServiceBusTriggeredEndpointConfiguration)} with the required parameter manually.");

--- a/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
@@ -5,8 +5,6 @@
     using Microsoft.Extensions.Logging;
     using Serverless;
     using System;
-    using System.Diagnostics;
-    using System.Reflection;
     using Microsoft.Extensions.Logging.Abstractions;
 
     /// <summary>
@@ -46,38 +44,13 @@
         /// </summary>
         public static ServiceBusTriggeredEndpointConfiguration CreateUsingFunctionAndTriggerAttributesInformation(FunctionExecutionContext functionExecutionContext)
         {
-            var configuration = TryGetTriggerConfiguration();
+            var configuration = TriggerDiscoverer.TryGet<ServiceBusTriggerAttribute>();
             if (configuration != null)
             {
                 return new ServiceBusTriggeredEndpointConfiguration(configuration.QueueName, functionExecutionContext.Logger ?? NullLogger.Instance, configuration.Connection);
             }
 
             throw new Exception($"Unable to automatically derive the endpoint name from the ServiceBusTrigger attribute. Make sure the attribute exists or create the {nameof(ServiceBusTriggeredEndpointConfiguration)} with the required parameter manually.");
-
-            ServiceBusTriggerAttribute TryGetTriggerConfiguration()
-            {
-                var frames = new StackTrace().GetFrames();
-                foreach (var stackFrame in frames)
-                {
-                    var method = stackFrame.GetMethod();
-                    var functionAttribute = method.GetCustomAttribute<FunctionNameAttribute>(false);
-                    if (functionAttribute != null)
-                    {
-                        foreach (var parameter in method.GetParameters())
-                        {
-                            var triggerConfiguration = parameter.GetCustomAttribute<ServiceBusTriggerAttribute>(false);
-                            if (triggerConfiguration != null)
-                            {
-                                return triggerConfiguration;
-                            }
-                        }
-                    }
-
-                    return null;
-                }
-
-                return null;
-            }
         }
     }
 }

--- a/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
@@ -1,10 +1,13 @@
 ﻿namespace NServiceBus.AzureFunctions.ServiceBus
 {
+    using Logging;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Extensions.Logging;
+    using Serverless;
     using System;
     using System.Diagnostics;
     using System.Reflection;
-    using Microsoft.Azure.WebJobs;
-    using Serverless;
+    using Microsoft.Extensions.Logging.Abstractions;
 
     /// <summary>
     /// Represents a serverless NServiceBus endpoint running within an AzureServiceBus trigger.
@@ -23,7 +26,7 @@
         /// <summary>
         /// Creates a serverless NServiceBus endpoint running within an Azure Service Bus trigger.
         /// </summary>
-        public ServiceBusTriggeredEndpointConfiguration(string endpointName, ILogger logger, string connectionStringName = "AzureWebJobsServiceBus") : base(endpointName)
+        public ServiceBusTriggeredEndpointConfiguration(string endpointName, ILogger logger, string connectionStringName = null) : base(endpointName)
         {
             Transport = UseTransport<AzureServiceBusTransport>();
 
@@ -39,14 +42,14 @@
         }
 
         /// <summary>
-        /// Attempts to derive the required configuration parameters automatically from the Azure functions related attributes via reflection.
+        /// Attempts to derive the required configuration parameters automatically from the Azure Functions related attributes via reflection.
         /// </summary>
         public static ServiceBusTriggeredEndpointConfiguration AutoConfigure()
         {
             var configuration = TryGetTriggerConfiguration();
             if (configuration != null)
             {
-                return new ServiceBusTriggeredEndpointConfiguration(configuration.QueueName, configuration.Connection);
+                return new ServiceBusTriggeredEndpointConfiguration(configuration.QueueName, NullLogger.Instance, configuration.Connection);
             }
 
             throw new Exception($"Unable to automatically derive the endpoint name from the ServiceBusTrigger attribute. Make sure the attribute exists or create the {nameof(ServiceBusTriggeredEndpointConfiguration)} with the required parameter manually.");

--- a/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
@@ -44,7 +44,7 @@
         /// <summary>
         /// Attempts to derive the required configuration parameters automatically from the Azure Functions related attributes via reflection.
         /// </summary>
-        public static ServiceBusTriggeredEndpointConfiguration AutoConfigure()
+        public static ServiceBusTriggeredEndpointConfiguration CreateUsingFunctionAndTriggerAttributesInformation()
         {
             var configuration = TryGetTriggerConfiguration();
             if (configuration != null)

--- a/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
@@ -46,38 +46,13 @@
         /// </summary>
         public static StorageQueueTriggeredEndpointConfiguration CreateUsingFunctionAndTriggerAttributesInformation(FunctionExecutionContext functionExecutionContext)
         {
-            var configuration = TryGetTriggerConfiguration();
+            var configuration = TriggerDiscoverer.TryGet<QueueTriggerAttribute>();
             if (configuration != null)
             {
                 return new StorageQueueTriggeredEndpointConfiguration(configuration.QueueName, functionExecutionContext.Logger ?? NullLogger.Instance, configuration.Connection);
             }
 
             throw new Exception($"Unable to automatically derive the endpoint name from the QueueTrigger attribute. Make sure the attribute exists or create the {nameof(StorageQueueTriggeredEndpointConfiguration)} with the required parameter manually.");
-
-            QueueTriggerAttribute TryGetTriggerConfiguration()
-            {
-                var frames = new StackTrace().GetFrames();
-                foreach (var stackFrame in frames)
-                {
-                    var method = stackFrame.GetMethod();
-                    var functionAttribute = method.GetCustomAttribute<FunctionNameAttribute>(false);
-                    if (functionAttribute != null)
-                    {
-                        foreach (var parameter in method.GetParameters())
-                        {
-                            var triggerConfiguration = parameter.GetCustomAttribute<QueueTriggerAttribute>(false);
-                            if (triggerConfiguration != null)
-                            {
-                                return triggerConfiguration;
-                            }
-                        }
-                    }
-
-                    return null;
-                }
-
-                return null;
-            }
         }
     }
 }

--- a/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
@@ -44,12 +44,12 @@
         /// <summary>
         /// Attempts to derive the required configuration parameters automatically from the Azure Functions related attributes via reflection.
         /// </summary>
-        public static StorageQueueTriggeredEndpointConfiguration CreateUsingFunctionAndTriggerAttributesInformation()
+        public static StorageQueueTriggeredEndpointConfiguration CreateUsingFunctionAndTriggerAttributesInformation(FunctionExecutionContext functionExecutionContext)
         {
             var configuration = TryGetTriggerConfiguration();
             if (configuration != null)
             {
-                return new StorageQueueTriggeredEndpointConfiguration(configuration.QueueName, NullLogger.Instance, configuration.Connection);
+                return new StorageQueueTriggeredEndpointConfiguration(configuration.QueueName, functionExecutionContext.Logger ?? NullLogger.Instance, configuration.Connection);
             }
 
             throw new Exception($"Unable to automatically derive the endpoint name from the QueueTrigger attribute. Make sure the attribute exists or create the {nameof(StorageQueueTriggeredEndpointConfiguration)} with the required parameter manually.");

--- a/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
@@ -6,6 +6,7 @@
     using System.Diagnostics;
     using System.Reflection;
     using Microsoft.Azure.WebJobs;
+    using Microsoft.Extensions.Logging.Abstractions;
     using Serverless;
 
     /// <summary>
@@ -25,7 +26,7 @@
         /// <summary>
         /// Creates a serverless NServiceBus endpoint running within an AzureStorageQueue trigger.
         /// </summary>
-        public StorageQueueTriggeredEndpointConfiguration(string endpointName, string connectionStringName = "AzureWebJobsStorage") : base(endpointName)
+        public StorageQueueTriggeredEndpointConfiguration(string endpointName, ILogger logger, string connectionStringName = null) : base(endpointName)
         {
             Transport = UseTransport<AzureStorageQueueTransport>();
 
@@ -41,14 +42,14 @@
         }
 
         /// <summary>
-        /// Attempts to derive the required configuration parameters automatically from the Azure functions related attributes via reflection.
+        /// Attempts to derive the required configuration parameters automatically from the Azure Functions related attributes via reflection.
         /// </summary>
-        public static StorageQueueTriggeredEndpointConfiguration AutoConfigure()
+        public static StorageQueueTriggeredEndpointConfiguration CreateUsingFunctionAndTriggerAttributesInformation()
         {
             var configuration = TryGetTriggerConfiguration();
             if (configuration != null)
             {
-                return new StorageQueueTriggeredEndpointConfiguration(configuration.QueueName, configuration.Connection);
+                return new StorageQueueTriggeredEndpointConfiguration(configuration.QueueName, NullLogger.Instance, configuration.Connection);
             }
 
             throw new Exception($"Unable to automatically derive the endpoint name from the QueueTrigger attribute. Make sure the attribute exists or create the {nameof(StorageQueueTriggeredEndpointConfiguration)} with the required parameter manually.");

--- a/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
@@ -3,8 +3,6 @@
     using Logging;
     using Microsoft.Extensions.Logging;
 	using System;
-    using System.Diagnostics;
-    using System.Reflection;
     using Microsoft.Azure.WebJobs;
     using Microsoft.Extensions.Logging.Abstractions;
     using Serverless;

--- a/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
@@ -2,6 +2,10 @@
 {
     using Logging;
     using Microsoft.Extensions.Logging;
+	using System;
+    using System.Diagnostics;
+    using System.Reflection;
+    using Microsoft.Azure.WebJobs;
     using Serverless;
 
     /// <summary>
@@ -9,6 +13,8 @@
     /// </summary>
     public class StorageQueueTriggeredEndpointConfiguration : ServerlessEndpointConfiguration
     {
+        const string DefaultStorageConnectionString = "AzureWebJobsStorage";
+
         /// <summary>
         /// Azure Storage Queues transport
         /// </summary>
@@ -19,11 +25,11 @@
         /// <summary>
         /// Creates a serverless NServiceBus endpoint running within an AzureStorageQueue trigger.
         /// </summary>
-        public StorageQueueTriggeredEndpointConfiguration(string endpointName, ILogger logger, string connectionStringName = "AzureWebJobsStorage") : base(endpointName)
+        public StorageQueueTriggeredEndpointConfiguration(string endpointName, string connectionStringName = "AzureWebJobsStorage") : base(endpointName)
         {
             Transport = UseTransport<AzureStorageQueueTransport>();
 
-            var connectionString = System.Environment.GetEnvironmentVariable(connectionStringName);
+            var connectionString = Environment.GetEnvironmentVariable(connectionStringName ?? DefaultStorageConnectionString);
             Transport.ConnectionString(connectionString);
 
             var recoverability = AdvancedConfiguration.Recoverability();
@@ -32,6 +38,45 @@
 
             FunctionsLoggerFactory = new FunctionsLoggerFactory(logger);
             LogManager.UseFactory(FunctionsLoggerFactory);
+        }
+
+        /// <summary>
+        /// Attempts to derive the required configuration parameters automatically from the Azure functions related attributes via reflection.
+        /// </summary>
+        public static StorageQueueTriggeredEndpointConfiguration AutoConfigure()
+        {
+            var configuration = TryGetTriggerConfiguration();
+            if (configuration != null)
+            {
+                return new StorageQueueTriggeredEndpointConfiguration(configuration.QueueName, configuration.Connection);
+            }
+
+            throw new Exception($"Unable to automatically derive the endpoint name from the QueueTrigger attribute. Make sure the attribute exists or create the {nameof(StorageQueueTriggeredEndpointConfiguration)} with the required parameter manually.");
+
+            QueueTriggerAttribute TryGetTriggerConfiguration()
+            {
+                var frames = new StackTrace().GetFrames();
+                foreach (var stackFrame in frames)
+                {
+                    var method = stackFrame.GetMethod();
+                    var functionAttribute = method.GetCustomAttribute<FunctionNameAttribute>(false);
+                    if (functionAttribute != null)
+                    {
+                        foreach (var parameter in method.GetParameters())
+                        {
+                            var triggerConfiguration = parameter.GetCustomAttribute<QueueTriggerAttribute>(false);
+                            if (triggerConfiguration != null)
+                            {
+                                return triggerConfiguration;
+                            }
+                        }
+                    }
+
+                    return null;
+                }
+
+                return null;
+            }
         }
     }
 }

--- a/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -18,6 +18,6 @@ namespace NServiceBus.AzureFunctions.ServiceBus
     {
         public ServiceBusTriggeredEndpointConfiguration(string endpointName, Microsoft.Extensions.Logging.ILogger logger, string connectionStringName = null) { }
         public NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> Transport { get; }
-        public static NServiceBus.AzureFunctions.ServiceBus.ServiceBusTriggeredEndpointConfiguration AutoConfigure() { }
+        public static NServiceBus.AzureFunctions.ServiceBus.ServiceBusTriggeredEndpointConfiguration CreateUsingFunctionAndTriggerAttributesInformation() { }
     }
 }

--- a/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -16,7 +16,7 @@ namespace NServiceBus.AzureFunctions.ServiceBus
     }
     public class ServiceBusTriggeredEndpointConfiguration : NServiceBus.Serverless.ServerlessEndpointConfiguration
     {
-        public ServiceBusTriggeredEndpointConfiguration(string endpointName, Microsoft.Extensions.Logging.ILogger logger, string connectionStringName = "AzureWebJobsServiceBus") { }
+        public ServiceBusTriggeredEndpointConfiguration(string endpointName, Microsoft.Extensions.Logging.ILogger logger, string connectionStringName = null) { }
         public NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> Transport { get; }
         public static NServiceBus.AzureFunctions.ServiceBus.ServiceBusTriggeredEndpointConfiguration AutoConfigure() { }
     }

--- a/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -18,5 +18,6 @@ namespace NServiceBus.AzureFunctions.ServiceBus
     {
         public ServiceBusTriggeredEndpointConfiguration(string endpointName, Microsoft.Extensions.Logging.ILogger logger, string connectionStringName = "AzureWebJobsServiceBus") { }
         public NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> Transport { get; }
+        public static NServiceBus.AzureFunctions.ServiceBus.ServiceBusTriggeredEndpointConfiguration AutoConfigure() { }
     }
 }

--- a/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -18,6 +18,6 @@ namespace NServiceBus.AzureFunctions.ServiceBus
     {
         public ServiceBusTriggeredEndpointConfiguration(string endpointName, Microsoft.Extensions.Logging.ILogger logger, string connectionStringName = null) { }
         public NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> Transport { get; }
-        public static NServiceBus.AzureFunctions.ServiceBus.ServiceBusTriggeredEndpointConfiguration CreateUsingFunctionAndTriggerAttributesInformation() { }
+        public static NServiceBus.AzureFunctions.ServiceBus.ServiceBusTriggeredEndpointConfiguration CreateUsingFunctionAndTriggerAttributesInformation(NServiceBus.AzureFunctions.FunctionExecutionContext functionExecutionContext) { }
     }
 }

--- a/src/Shared/AttributeDiscoverer.cs
+++ b/src/Shared/AttributeDiscoverer.cs
@@ -28,8 +28,6 @@ namespace NServiceBus.AzureFunctions
                         }
                     }
                 }
-
-                return null;
             }
 
             return null;

--- a/src/Shared/AttributeDiscoverer.cs
+++ b/src/Shared/AttributeDiscoverer.cs
@@ -1,0 +1,38 @@
+namespace NServiceBus.AzureFunctions
+{
+    using System;
+    using System.Diagnostics;
+    using System.Reflection;
+    using Microsoft.Azure.WebJobs;
+
+    class TriggerDiscoverer
+    {
+        /// <summary>
+        /// Attempts to derive the required configuration information from the Azure Function and trigger attributes via reflection.
+        /// </summary>
+        public static TTransportTriggerAttribute TryGet<TTransportTriggerAttribute>() where TTransportTriggerAttribute : Attribute
+        {
+            var frames = new StackTrace().GetFrames();
+            foreach (var stackFrame in frames)
+            {
+                var method = stackFrame.GetMethod();
+                var functionAttribute = method.GetCustomAttribute<FunctionNameAttribute>(false);
+                if (functionAttribute != null)
+                {
+                    foreach (var parameter in method.GetParameters())
+                    {
+                        var triggerConfiguration = parameter.GetCustomAttribute<TTransportTriggerAttribute>(false);
+                        if (triggerConfiguration != null)
+                        {
+                            return triggerConfiguration;
+                        }
+                    }
+                }
+
+                return null;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/StorageQueues.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/StorageQueues.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -18,6 +18,6 @@ namespace NServiceBus.AzureFunctions.StorageQueues
     {
         public StorageQueueTriggeredEndpointConfiguration(string endpointName, Microsoft.Extensions.Logging.ILogger logger, string connectionStringName = null) { }
         public NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> Transport { get; }
-        public static NServiceBus.AzureFunctions.StorageQueues.StorageQueueTriggeredEndpointConfiguration CreateUsingFunctionAndTriggerAttributesInformation() { }
+        public static NServiceBus.AzureFunctions.StorageQueues.StorageQueueTriggeredEndpointConfiguration CreateUsingFunctionAndTriggerAttributesInformation(NServiceBus.AzureFunctions.FunctionExecutionContext functionExecutionContext) { }
     }
 }

--- a/src/StorageQueues.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/StorageQueues.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -16,8 +16,8 @@ namespace NServiceBus.AzureFunctions.StorageQueues
     }
     public class StorageQueueTriggeredEndpointConfiguration : NServiceBus.Serverless.ServerlessEndpointConfiguration
     {
-        public StorageQueueTriggeredEndpointConfiguration(string endpointName, Microsoft.Extensions.Logging.ILogger logger, string connectionStringName = "AzureWebJobsStorage") { }
+        public StorageQueueTriggeredEndpointConfiguration(string endpointName, Microsoft.Extensions.Logging.ILogger logger, string connectionStringName = null) { }
         public NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> Transport { get; }
-        public static NServiceBus.AzureFunctions.StorageQueues.StorageQueueTriggeredEndpointConfiguration AutoConfigure() { }
+        public static NServiceBus.AzureFunctions.StorageQueues.StorageQueueTriggeredEndpointConfiguration CreateUsingFunctionAndTriggerAttributesInformation() { }
     }
 }

--- a/src/StorageQueues.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/StorageQueues.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -18,5 +18,6 @@ namespace NServiceBus.AzureFunctions.StorageQueues
     {
         public StorageQueueTriggeredEndpointConfiguration(string endpointName, Microsoft.Extensions.Logging.ILogger logger, string connectionStringName = "AzureWebJobsStorage") { }
         public NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> Transport { get; }
+        public static NServiceBus.AzureFunctions.StorageQueues.StorageQueueTriggeredEndpointConfiguration AutoConfigure() { }
     }
 }


### PR DESCRIPTION
We can use reflection to walk up the stack trace and find the trigger specific attributes. From these attributes we can use the endpoint name and optionally the connection name so users don't have to repeat this information unnecessarily.

Because the endpoint name is a ctor param on the base configuration class, I've just went with a static factory which goes on a strack trace hike so users can always fall back to passing the params manually. Not sure about the naming but I didn't come up with something better quickly.

If we go with David's PR using the shared assembly, we might be able to move some of this code to the shared assembly.