### PR TITLE
Alternative logger

### DIFF
--- a/src/NServiceBus.AzureFunctions.ServiceBus/FunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/FunctionEndpoint.cs
@@ -29,11 +29,11 @@
         public async Task Process(Message message, ExecutionContext executionContext, ILogger functionsLogger = null)
         {
             var messageContext = CreateMessageContext(message);
-            var context = new FunctionExecutionContext(executionContext, functionsLogger);
+            var functionContext = new FunctionExecutionContext(executionContext, functionsLogger);
 
             try
             {
-                await Process(messageContext, context).ConfigureAwait(false);
+                await Process(messageContext, functionContext).ConfigureAwait(false);
             }
             catch (Exception exception)
             {
@@ -45,7 +45,7 @@
                     new TransportTransaction(), 
                     message.SystemProperties.DeliveryCount);
 
-                var errorHandleResult = await ProcessFailedMessage(errorContext, context)
+                var errorHandleResult = await ProcessFailedMessage(errorContext, functionContext)
                     .ConfigureAwait(false);
 
                 if (errorHandleResult == ErrorHandleResult.Handled)

--- a/src/NServiceBus.AzureFunctions.ServiceBus/NServiceBus.AzureFunctions.ServiceBus.csproj
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/NServiceBus.AzureFunctions.ServiceBus.csproj
@@ -14,4 +14,8 @@
     <PackageReference Include="Particular.Packaging" Version="0.3.0" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\Shared\**\*.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AzureFunctions.ServiceBus
 {
-    using NServiceBus.Logging;
+    using Microsoft.Extensions.Logging;
+    using Logging;
     using Serverless;
 
     /// <summary>
@@ -18,7 +19,7 @@
         /// <summary>
         /// Creates a serverless NServiceBus endpoint running within an Azure Service Bus trigger.
         /// </summary>
-        public ServiceBusTriggeredEndpointConfiguration(string endpointName, string connectionStringName = "AzureWebJobsServiceBus") : base(endpointName)
+        public ServiceBusTriggeredEndpointConfiguration(string endpointName, ILogger logger, string connectionStringName = "AzureWebJobsServiceBus") : base(endpointName)
         {
             Transport = UseTransport<AzureServiceBusTransport>();
 
@@ -29,7 +30,7 @@
             recoverability.Immediate(settings => settings.NumberOfRetries(5));
             recoverability.Delayed(settings => settings.NumberOfRetries(3));
 
-            FunctionsLoggerFactory = new FunctionsLoggerFactory();
+            FunctionsLoggerFactory = new FunctionsLoggerFactory(logger);
             LogManager.UseFactory(FunctionsLoggerFactory);
         }
     }

--- a/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AzureFunctions.ServiceBus
 {
+    using NServiceBus.Logging;
     using Serverless;
 
     /// <summary>
@@ -11,6 +12,8 @@
         /// Azure Service Bus transport
         /// </summary>
         public TransportExtensions<AzureServiceBusTransport> Transport { get; }
+
+        internal FunctionsLoggerFactory FunctionsLoggerFactory { get; }
 
         /// <summary>
         /// Creates a serverless NServiceBus endpoint running within an Azure Service Bus trigger.
@@ -25,6 +28,9 @@
             var recoverability = AdvancedConfiguration.Recoverability();
             recoverability.Immediate(settings => settings.NumberOfRetries(5));
             recoverability.Delayed(settings => settings.NumberOfRetries(3));
+
+            FunctionsLoggerFactory = new FunctionsLoggerFactory();
+            LogManager.UseFactory(FunctionsLoggerFactory);
         }
     }
 }

--- a/src/NServiceBus.AzureFunctions.StorageQueues/FunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/FunctionEndpoint.cs
@@ -31,7 +31,7 @@
         /// </summary>
         public async Task Process(CloudQueueMessage message, ExecutionContext executionContext, ILogger functionsLogger = null)
         {
-            var context = new FunctionExecutionContext(executionContext, functionsLogger);
+            var functionContext = new FunctionExecutionContext(executionContext, functionsLogger);
 
             MessageWrapper wrapper;
             // Read message content via StreamReader to handle BOM correctly.
@@ -45,7 +45,7 @@
 
             try
             {
-                await Process(messageContext, context).ConfigureAwait(false);
+                await Process(messageContext, functionContext).ConfigureAwait(false);
             }
             catch (Exception exception)
             {
@@ -57,7 +57,7 @@
                     new TransportTransaction(),
                     message.DequeueCount);
 
-                var errorHandleResult = await ProcessFailedMessage(errorContext, context)
+                var errorHandleResult = await ProcessFailedMessage(errorContext, functionContext)
                     .ConfigureAwait(false);
 
                 if (errorHandleResult == ErrorHandleResult.Handled)

--- a/src/NServiceBus.AzureFunctions.StorageQueues/NServiceBus.AzureFunctions.StorageQueues.csproj
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/NServiceBus.AzureFunctions.StorageQueues.csproj
@@ -14,4 +14,8 @@
     <PackageReference Include="Particular.Packaging" Version="0.3.0" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\Shared\**\*.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
@@ -1,7 +1,7 @@
 ﻿namespace NServiceBus.AzureFunctions.StorageQueues
 {
+    using Logging;
     using Microsoft.Extensions.Logging;
-    using NServiceBus.Logging;
     using Serverless;
 
     /// <summary>

--- a/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AzureFunctions.StorageQueues
 {
+    using NServiceBus.Logging;
     using Serverless;
 
     /// <summary>
@@ -11,6 +12,8 @@
         /// Azure Storage Queues transport
         /// </summary>
         public TransportExtensions<AzureStorageQueueTransport> Transport { get; }
+
+        internal FunctionsLoggerFactory FunctionsLoggerFactory { get; }
 
         /// <summary>
         /// Creates a serverless NServiceBus endpoint running within an AzureStorageQueue trigger.
@@ -25,6 +28,9 @@
             var recoverability = AdvancedConfiguration.Recoverability();
             recoverability.Immediate(settings => settings.NumberOfRetries(4));
             recoverability.Delayed(settings => settings.NumberOfRetries(0));
+
+            FunctionsLoggerFactory = new FunctionsLoggerFactory();
+            LogManager.UseFactory(FunctionsLoggerFactory);
         }
     }
 }

--- a/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AzureFunctions.StorageQueues
 {
+    using Microsoft.Extensions.Logging;
     using NServiceBus.Logging;
     using Serverless;
 
@@ -18,7 +19,7 @@
         /// <summary>
         /// Creates a serverless NServiceBus endpoint running within an AzureStorageQueue trigger.
         /// </summary>
-        public StorageQueueTriggeredEndpointConfiguration(string endpointName, string connectionStringName = "AzureWebJobsStorage") : base(endpointName)
+        public StorageQueueTriggeredEndpointConfiguration(string endpointName, ILogger logger, string connectionStringName = "AzureWebJobsStorage") : base(endpointName)
         {
             Transport = UseTransport<AzureStorageQueueTransport>();
 
@@ -29,7 +30,7 @@
             recoverability.Immediate(settings => settings.NumberOfRetries(4));
             recoverability.Delayed(settings => settings.NumberOfRetries(0));
 
-            FunctionsLoggerFactory = new FunctionsLoggerFactory();
+            FunctionsLoggerFactory = new FunctionsLoggerFactory(logger);
             LogManager.UseFactory(FunctionsLoggerFactory);
         }
     }

--- a/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -1,13 +1,22 @@
+namespace NServiceBus.AzureFunctions
+{
+    public class FunctionExecutionContext
+    {
+        public FunctionExecutionContext(Microsoft.Azure.WebJobs.ExecutionContext context, Microsoft.Extensions.Logging.ILogger logger = null) { }
+        public Microsoft.Azure.WebJobs.ExecutionContext Context { get; }
+        public Microsoft.Extensions.Logging.ILogger Logger { get; }
+    }
+}
 namespace NServiceBus.AzureFunctions.ServiceBus
 {
-    public class FunctionEndpoint : NServiceBus.Serverless.ServerlessEndpoint<Microsoft.Azure.WebJobs.ExecutionContext, NServiceBus.AzureFunctions.ServiceBus.ServiceBusTriggeredEndpointConfiguration>
+    public class FunctionEndpoint : NServiceBus.Serverless.ServerlessEndpoint<NServiceBus.AzureFunctions.FunctionExecutionContext, NServiceBus.AzureFunctions.ServiceBus.ServiceBusTriggeredEndpointConfiguration>
     {
-        public FunctionEndpoint(System.Func<Microsoft.Azure.WebJobs.ExecutionContext, NServiceBus.AzureFunctions.ServiceBus.ServiceBusTriggeredEndpointConfiguration> configurationFactory) { }
-        public System.Threading.Tasks.Task Process(Microsoft.Azure.ServiceBus.Message message, Microsoft.Azure.WebJobs.ExecutionContext executionContext) { }
+        public FunctionEndpoint(System.Func<NServiceBus.AzureFunctions.FunctionExecutionContext, NServiceBus.AzureFunctions.ServiceBus.ServiceBusTriggeredEndpointConfiguration> configurationFactory) { }
+        public System.Threading.Tasks.Task Process(Microsoft.Azure.ServiceBus.Message message, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null) { }
     }
     public class ServiceBusTriggeredEndpointConfiguration : NServiceBus.Serverless.ServerlessEndpointConfiguration
     {
-        public ServiceBusTriggeredEndpointConfiguration(string endpointName, string connectionStringName = "AzureWebJobsServiceBus") { }
+        public ServiceBusTriggeredEndpointConfiguration(string endpointName, Microsoft.Extensions.Logging.ILogger logger, string connectionStringName = "AzureWebJobsServiceBus") { }
         public NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> Transport { get; }
     }
 }

--- a/src/Shared/FunctionExecutionContext.cs
+++ b/src/Shared/FunctionExecutionContext.cs
@@ -1,0 +1,18 @@
+namespace NServiceBus.AzureFunctions
+{
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    public class FunctionExecutionContext
+    {
+        public FunctionExecutionContext(ExecutionContext context, ILogger logger = null)
+        {
+            Logger = logger ?? NullLogger.Instance;
+            Context = context;
+        }
+
+        public ExecutionContext Context { get; }
+        public ILogger Logger { get; }
+    }
+}

--- a/src/Shared/FunctionExecutionContext.cs
+++ b/src/Shared/FunctionExecutionContext.cs
@@ -4,15 +4,27 @@ namespace NServiceBus.AzureFunctions
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Logging.Abstractions;
 
+    /// <summary>
+    /// Function execution context
+    /// </summary>
     public class FunctionExecutionContext
     {
+        /// <summary>
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="logger"></param>
         public FunctionExecutionContext(ExecutionContext context, ILogger logger = null)
         {
             Logger = logger ?? NullLogger.Instance;
             Context = context;
         }
 
+        /// <summary>
+        /// </summary>
         public ExecutionContext Context { get; }
+        
+        /// <summary>
+        /// </summary>
         public ILogger Logger { get; }
     }
 }

--- a/src/Shared/Logging/FunctionsLoggerFactory.cs
+++ b/src/Shared/Logging/FunctionsLoggerFactory.cs
@@ -1,23 +1,28 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading;
-using NServiceBus.Logging;
-
-namespace NServiceBus.AzureFunctions
+﻿namespace NServiceBus.AzureFunctions
 {
-    class FunctionsLoggerFactory : NServiceBus.Logging.ILoggerFactory
+    using System;
+    using Logging;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+    using ILoggerFactory = Logging.ILoggerFactory;
+
+    class FunctionsLoggerFactory : ILoggerFactory
     {
+        public FunctionsLoggerFactory(ILogger logger)
+        {
+            this.logger = logger ?? NullLogger.Instance;
+        }
+
         public ILog GetLogger(Type type)
         {
-            return new Logger(this, type.Name);
+            return new Logger(logger);
         }
 
         public ILog GetLogger(string name)
         {
-            return new Logger(this, name);
+            return new Logger(logger);
         }
 
-        public Microsoft.Extensions.Logging.ILogger Logger { get; internal set; }
+        readonly ILogger logger;
     }
 }

--- a/src/Shared/Logging/FunctionsLoggerFactory.cs
+++ b/src/Shared/Logging/FunctionsLoggerFactory.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using NServiceBus.Logging;
+
+namespace NServiceBus.AzureFunctions
+{
+    class FunctionsLoggerFactory : NServiceBus.Logging.ILoggerFactory
+    {
+        public ILog GetLogger(Type type)
+        {
+            return new Logger(this, type.Name);
+        }
+
+        public ILog GetLogger(string name)
+        {
+            return new Logger(this, name);
+        }
+
+        public Microsoft.Extensions.Logging.ILogger Logger { get; internal set; }
+    }
+}

--- a/src/Shared/Logging/Logger.cs
+++ b/src/Shared/Logging/Logger.cs
@@ -1,102 +1,98 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.Extensions.Logging;
-
-namespace NServiceBus.AzureFunctions
+﻿namespace NServiceBus.AzureFunctions
 {
-    class Logger : NServiceBus.Logging.ILog
-    {
-        FunctionsLoggerFactory loggerFactory;
-        string loggerName;
+    using System;
+    using Logging;
+    using Microsoft.Extensions.Logging;
+    using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
-        public Logger(FunctionsLoggerFactory loggerFactory, string loggerName)
+    class Logger : ILog
+    {
+        public Logger(ILogger logger)
         {
-            this.loggerFactory = loggerFactory;
-            this.loggerName = loggerName;
+            this.logger = logger;
         }
 
-        ILogger log => this.loggerFactory.Logger;
-
-        public bool IsDebugEnabled => log.IsEnabled(LogLevel.Debug);
-        public bool IsInfoEnabled => log.IsEnabled(LogLevel.Information);
-        public bool IsWarnEnabled => log.IsEnabled(LogLevel.Warning);
-        public bool IsErrorEnabled => log.IsEnabled(LogLevel.Error);
-        public bool IsFatalEnabled => log.IsEnabled(LogLevel.Error);
+        public bool IsDebugEnabled => logger.IsEnabled(LogLevel.Debug);
+        public bool IsInfoEnabled => logger.IsEnabled(LogLevel.Information);
+        public bool IsWarnEnabled => logger.IsEnabled(LogLevel.Warning);
+        public bool IsErrorEnabled => logger.IsEnabled(LogLevel.Error);
+        public bool IsFatalEnabled => logger.IsEnabled(LogLevel.Error);
 
         public void Debug(string message)
         {
-            log.Log(LogLevel.Debug, message);
+            logger.Log(LogLevel.Debug, message);
         }
 
         public void Debug(string message, Exception exception)
         {
-            log.Log(LogLevel.Debug, exception, message);
+            logger.Log(LogLevel.Debug, exception, message);
         }
 
         public void DebugFormat(string format, params object[] args)
         {
-            log.Log(LogLevel.Debug, format, args);
+            logger.Log(LogLevel.Debug, format, args);
         }
 
         public void Info(string message)
         {
-            log.Log(LogLevel.Information, message);
+            logger.Log(LogLevel.Information, message);
         }
 
         public void Info(string message, Exception exception)
         {
-            log.Log(LogLevel.Information, exception, message);
+            logger.Log(LogLevel.Information, exception, message);
         }
 
         public void InfoFormat(string format, params object[] args)
         {
-            log.Log(LogLevel.Information, format, args);
+            logger.Log(LogLevel.Information, format, args);
         }
 
         public void Warn(string message)
         {
-            log.Log(LogLevel.Warning, message);
+            logger.Log(LogLevel.Warning, message);
         }
 
         public void Warn(string message, Exception exception)
         {
-            log.Log(LogLevel.Warning, exception, message);
+            logger.Log(LogLevel.Warning, exception, message);
         }
 
         public void WarnFormat(string format, params object[] args)
         {
-            log.Log(LogLevel.Warning, format, args);
+            logger.Log(LogLevel.Warning, format, args);
         }
 
         public void Error(string message)
         {
-            log.Log(LogLevel.Error, message);
+            logger.Log(LogLevel.Error, message);
         }
 
         public void Error(string message, Exception exception)
         {
-            log.Log(LogLevel.Error, exception, message);
+            logger.Log(LogLevel.Error, exception, message);
         }
 
         public void ErrorFormat(string format, params object[] args)
         {
-            log.Log(LogLevel.Error, format, args);
+            logger.Log(LogLevel.Error, format, args);
         }
 
         public void Fatal(string message)
         {
-            log.Log(LogLevel.Error, message);
+            logger.Log(LogLevel.Error, message);
         }
 
         public void Fatal(string message, Exception exception)
         {
-            log.Log(LogLevel.Error, exception, message);
+            logger.Log(LogLevel.Error, exception, message);
         }
 
         public void FatalFormat(string format, params object[] args)
         {
-            log.Log(LogLevel.Error, format, args);
+            logger.Log(LogLevel.Error, format, args);
         }
+
+        ILogger logger;
     }
 }

--- a/src/Shared/Logging/Logger.cs
+++ b/src/Shared/Logging/Logger.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace NServiceBus.AzureFunctions
+{
+    class Logger : NServiceBus.Logging.ILog
+    {
+        FunctionsLoggerFactory loggerFactory;
+        string loggerName;
+
+        public Logger(FunctionsLoggerFactory loggerFactory, string loggerName)
+        {
+            this.loggerFactory = loggerFactory;
+            this.loggerName = loggerName;
+        }
+
+        ILogger log => this.loggerFactory.Logger;
+
+        public bool IsDebugEnabled => log.IsEnabled(LogLevel.Debug);
+        public bool IsInfoEnabled => log.IsEnabled(LogLevel.Information);
+        public bool IsWarnEnabled => log.IsEnabled(LogLevel.Warning);
+        public bool IsErrorEnabled => log.IsEnabled(LogLevel.Error);
+        public bool IsFatalEnabled => log.IsEnabled(LogLevel.Error);
+
+        public void Debug(string message)
+        {
+            log.Log(LogLevel.Debug, message);
+        }
+
+        public void Debug(string message, Exception exception)
+        {
+            log.Log(LogLevel.Debug, exception, message);
+        }
+
+        public void DebugFormat(string format, params object[] args)
+        {
+            log.Log(LogLevel.Debug, format, args);
+        }
+
+        public void Info(string message)
+        {
+            log.Log(LogLevel.Information, message);
+        }
+
+        public void Info(string message, Exception exception)
+        {
+            log.Log(LogLevel.Information, exception, message);
+        }
+
+        public void InfoFormat(string format, params object[] args)
+        {
+            log.Log(LogLevel.Information, format, args);
+        }
+
+        public void Warn(string message)
+        {
+            log.Log(LogLevel.Warning, message);
+        }
+
+        public void Warn(string message, Exception exception)
+        {
+            log.Log(LogLevel.Warning, exception, message);
+        }
+
+        public void WarnFormat(string format, params object[] args)
+        {
+            log.Log(LogLevel.Warning, format, args);
+        }
+
+        public void Error(string message)
+        {
+            log.Log(LogLevel.Error, message);
+        }
+
+        public void Error(string message, Exception exception)
+        {
+            log.Log(LogLevel.Error, exception, message);
+        }
+
+        public void ErrorFormat(string format, params object[] args)
+        {
+            log.Log(LogLevel.Error, format, args);
+        }
+
+        public void Fatal(string message)
+        {
+            log.Log(LogLevel.Error, message);
+        }
+
+        public void Fatal(string message, Exception exception)
+        {
+            log.Log(LogLevel.Error, exception, message);
+        }
+
+        public void FatalFormat(string format, params object[] args)
+        {
+            log.Log(LogLevel.Error, format, args);
+        }
+    }
+}

--- a/src/StorageQueues.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/StorageQueues.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -1,13 +1,22 @@
+namespace NServiceBus.AzureFunctions
+{
+    public class FunctionExecutionContext
+    {
+        public FunctionExecutionContext(Microsoft.Azure.WebJobs.ExecutionContext context, Microsoft.Extensions.Logging.ILogger logger = null) { }
+        public Microsoft.Azure.WebJobs.ExecutionContext Context { get; }
+        public Microsoft.Extensions.Logging.ILogger Logger { get; }
+    }
+}
 namespace NServiceBus.AzureFunctions.StorageQueues
 {
-    public class FunctionEndpoint : NServiceBus.Serverless.ServerlessEndpoint<Microsoft.Azure.WebJobs.ExecutionContext, NServiceBus.AzureFunctions.StorageQueues.StorageQueueTriggeredEndpointConfiguration>
+    public class FunctionEndpoint : NServiceBus.Serverless.ServerlessEndpoint<NServiceBus.AzureFunctions.FunctionExecutionContext, NServiceBus.AzureFunctions.StorageQueues.StorageQueueTriggeredEndpointConfiguration>
     {
-        public FunctionEndpoint(System.Func<Microsoft.Azure.WebJobs.ExecutionContext, NServiceBus.AzureFunctions.StorageQueues.StorageQueueTriggeredEndpointConfiguration> configurationFactory) { }
-        public System.Threading.Tasks.Task Process(Microsoft.WindowsAzure.Storage.Queue.CloudQueueMessage message, Microsoft.Azure.WebJobs.ExecutionContext executionContext) { }
+        public FunctionEndpoint(System.Func<NServiceBus.AzureFunctions.FunctionExecutionContext, NServiceBus.AzureFunctions.StorageQueues.StorageQueueTriggeredEndpointConfiguration> configurationFactory) { }
+        public System.Threading.Tasks.Task Process(Microsoft.WindowsAzure.Storage.Queue.CloudQueueMessage message, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null) { }
     }
     public class StorageQueueTriggeredEndpointConfiguration : NServiceBus.Serverless.ServerlessEndpointConfiguration
     {
-        public StorageQueueTriggeredEndpointConfiguration(string endpointName, string connectionStringName = "AzureWebJobsStorage") { }
+        public StorageQueueTriggeredEndpointConfiguration(string endpointName, Microsoft.Extensions.Logging.ILogger logger, string connectionStringName = "AzureWebJobsStorage") { }
         public NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> Transport { get; }
     }
 }


### PR DESCRIPTION
An alternative to #21 

This PR introduces `FunctionExecutionContext` that is populated with `ILogger`. Which can be provided to the configuration lambda code.