### PR TITLE
Stop walking the stack once the functions attribute has been found

### DIFF
--- a/src/Shared/AttributeDiscoverer.cs
+++ b/src/Shared/AttributeDiscoverer.cs
@@ -27,6 +27,8 @@ namespace NServiceBus.AzureFunctions
                             return triggerConfiguration;
                         }
                     }
+
+                    return null;
                 }
             }
 


### PR DESCRIPTION
adding the `return null` back in, but this time at the right place ;) 

If the code found the `FunctionName` attribute (the trigger function) and can't find the trigger specific attribute on it's parameters we don't need to traverse the stack any further.