### PR TITLE
Shorten naming for attribute based config

### DIFF
--- a/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
@@ -42,7 +42,7 @@
         /// <summary>
         /// Attempts to derive the required configuration parameters automatically from the Azure Functions related attributes via reflection.
         /// </summary>
-        public static ServiceBusTriggeredEndpointConfiguration CreateUsingFunctionAndTriggerAttributesInformation(FunctionExecutionContext functionExecutionContext)
+        public static ServiceBusTriggeredEndpointConfiguration FromAttributes(FunctionExecutionContext functionExecutionContext)
         {
             var configuration = TriggerDiscoverer.TryGet<ServiceBusTriggerAttribute>();
             if (configuration != null)

--- a/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
@@ -42,7 +42,7 @@
         /// <summary>
         /// Attempts to derive the required configuration parameters automatically from the Azure Functions related attributes via reflection.
         /// </summary>
-        public static StorageQueueTriggeredEndpointConfiguration CreateUsingFunctionAndTriggerAttributesInformation(FunctionExecutionContext functionExecutionContext)
+        public static StorageQueueTriggeredEndpointConfiguration FromAttributes(FunctionExecutionContext functionExecutionContext)
         {
             var configuration = TriggerDiscoverer.TryGet<QueueTriggerAttribute>();
             if (configuration != null)

--- a/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -18,6 +18,6 @@ namespace NServiceBus.AzureFunctions.ServiceBus
     {
         public ServiceBusTriggeredEndpointConfiguration(string endpointName, Microsoft.Extensions.Logging.ILogger logger, string connectionStringName = null) { }
         public NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> Transport { get; }
-        public static NServiceBus.AzureFunctions.ServiceBus.ServiceBusTriggeredEndpointConfiguration CreateUsingFunctionAndTriggerAttributesInformation(NServiceBus.AzureFunctions.FunctionExecutionContext functionExecutionContext) { }
+        public static NServiceBus.AzureFunctions.ServiceBus.ServiceBusTriggeredEndpointConfiguration FromAttributes(NServiceBus.AzureFunctions.FunctionExecutionContext functionExecutionContext) { }
     }
 }

--- a/src/StorageQueues.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/StorageQueues.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -18,6 +18,6 @@ namespace NServiceBus.AzureFunctions.StorageQueues
     {
         public StorageQueueTriggeredEndpointConfiguration(string endpointName, Microsoft.Extensions.Logging.ILogger logger, string connectionStringName = null) { }
         public NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> Transport { get; }
-        public static NServiceBus.AzureFunctions.StorageQueues.StorageQueueTriggeredEndpointConfiguration CreateUsingFunctionAndTriggerAttributesInformation(NServiceBus.AzureFunctions.FunctionExecutionContext functionExecutionContext) { }
+        public static NServiceBus.AzureFunctions.StorageQueues.StorageQueueTriggeredEndpointConfiguration FromAttributes(NServiceBus.AzureFunctions.FunctionExecutionContext functionExecutionContext) { }
     }
 }


### PR DESCRIPTION
`ServiceBusTriggeredEndpointConfiguration.CreateUsingFunctionAndTriggerAttributesInformation` is terribly long without really communicating much information imo. Let's try to shorten that down a bit.