### PR TITLE
Reintroduce FunctionExecutionContext

### DIFF
--- a/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -1,8 +1,17 @@
+namespace NServiceBus.AzureFunctions
+{
+    public class FunctionExecutionContext
+    {
+        public FunctionExecutionContext(Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger logger) { }
+        public Microsoft.Azure.WebJobs.ExecutionContext ExecutionContext { get; }
+        public Microsoft.Extensions.Logging.ILogger Logger { get; }
+    }
+}
 namespace NServiceBus.AzureFunctions.ServiceBus
 {
-    public class FunctionEndpoint : NServiceBus.Serverless.ServerlessEndpoint<Microsoft.Azure.WebJobs.ExecutionContext, NServiceBus.AzureFunctions.ServiceBus.ServiceBusTriggeredEndpointConfiguration>
+    public class FunctionEndpoint : NServiceBus.Serverless.ServerlessEndpoint<NServiceBus.AzureFunctions.FunctionExecutionContext, NServiceBus.AzureFunctions.ServiceBus.ServiceBusTriggeredEndpointConfiguration>
     {
-        public FunctionEndpoint(System.Func<Microsoft.Azure.WebJobs.ExecutionContext, NServiceBus.AzureFunctions.ServiceBus.ServiceBusTriggeredEndpointConfiguration> configurationFactory) { }
+        public FunctionEndpoint(System.Func<NServiceBus.AzureFunctions.FunctionExecutionContext, NServiceBus.AzureFunctions.ServiceBus.ServiceBusTriggeredEndpointConfiguration> configurationFactory) { }
         public System.Threading.Tasks.Task Process(Microsoft.Azure.ServiceBus.Message message, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null) { }
     }
     public class ServiceBusTriggeredEndpointConfiguration : NServiceBus.Serverless.ServerlessEndpointConfiguration

--- a/src/Shared/FunctionExecutionContext.cs
+++ b/src/Shared/FunctionExecutionContext.cs
@@ -4,13 +4,13 @@ namespace NServiceBus.AzureFunctions
     using Microsoft.Extensions.Logging;
 
     /// <summary>
+    /// Contains specific context information of the current function invocation.
     /// </summary>
     public class FunctionExecutionContext
     {
         /// <summary>
+        /// Creates a new <see cref="FunctionExecutionContext"/>.
         /// </summary>
-        /// <param name="logger"></param>
-        /// <param name="executionContext"></param>
         public FunctionExecutionContext(ExecutionContext executionContext, ILogger logger)
         {
             Logger = logger;
@@ -18,10 +18,12 @@ namespace NServiceBus.AzureFunctions
         }
 
         /// <summary>
+        /// The <see cref="ExecutionContext"/> associated with the current function invocation.
         /// </summary>
         public ExecutionContext ExecutionContext { get; }
 
         /// <summary>
+        /// The <see cref="ILogger"/> associated with the current function invocation.
         /// </summary>
         public ILogger Logger { get; }
     }

--- a/src/Shared/FunctionExecutionContext.cs
+++ b/src/Shared/FunctionExecutionContext.cs
@@ -1,0 +1,28 @@
+namespace NServiceBus.AzureFunctions
+{
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Extensions.Logging;
+
+    /// <summary>
+    /// </summary>
+    public class FunctionExecutionContext
+    {
+        /// <summary>
+        /// </summary>
+        /// <param name="logger"></param>
+        /// <param name="executionContext"></param>
+        public FunctionExecutionContext(ExecutionContext executionContext, ILogger logger)
+        {
+            Logger = logger;
+            ExecutionContext = executionContext;
+        }
+
+        /// <summary>
+        /// </summary>
+        public ExecutionContext ExecutionContext { get; }
+
+        /// <summary>
+        /// </summary>
+        public ILogger Logger { get; }
+    }
+}

--- a/src/StorageQueues.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/StorageQueues.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -1,8 +1,17 @@
+namespace NServiceBus.AzureFunctions
+{
+    public class FunctionExecutionContext
+    {
+        public FunctionExecutionContext(Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger logger) { }
+        public Microsoft.Azure.WebJobs.ExecutionContext ExecutionContext { get; }
+        public Microsoft.Extensions.Logging.ILogger Logger { get; }
+    }
+}
 namespace NServiceBus.AzureFunctions.StorageQueues
 {
-    public class FunctionEndpoint : NServiceBus.Serverless.ServerlessEndpoint<Microsoft.Azure.WebJobs.ExecutionContext, NServiceBus.AzureFunctions.StorageQueues.StorageQueueTriggeredEndpointConfiguration>
+    public class FunctionEndpoint : NServiceBus.Serverless.ServerlessEndpoint<NServiceBus.AzureFunctions.FunctionExecutionContext, NServiceBus.AzureFunctions.StorageQueues.StorageQueueTriggeredEndpointConfiguration>
     {
-        public FunctionEndpoint(System.Func<Microsoft.Azure.WebJobs.ExecutionContext, NServiceBus.AzureFunctions.StorageQueues.StorageQueueTriggeredEndpointConfiguration> configurationFactory) { }
+        public FunctionEndpoint(System.Func<NServiceBus.AzureFunctions.FunctionExecutionContext, NServiceBus.AzureFunctions.StorageQueues.StorageQueueTriggeredEndpointConfiguration> configurationFactory) { }
         public System.Threading.Tasks.Task Process(Microsoft.WindowsAzure.Storage.Queue.CloudQueueMessage message, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null) { }
     }
     public class StorageQueueTriggeredEndpointConfiguration : NServiceBus.Serverless.ServerlessEndpointConfiguration


### PR DESCRIPTION
Fixes #33

This PR partially reverts changes made in PR  #31 by re-introducing `FunctionExecutionContext` used to wrap Functions' `ExecutionContext` and `ILogger`.

The change made in #31 has caused the samples to break and removed the ability to log information during endpoint's configuration/creating. NServiceBus.Serverless allows a single argument to be passed into the callback. That argument is the context of the function execution. A logger passed into the function call should be part of that context.

Rationale: discourage usage of the [static `LogManager`](https://github.com/Particular/docs.particular.net/pull/4482) in favour of the context object to access the logger. See usage in this [PR description](https://github.com/Particular/docs.particular.net/pull/4483).